### PR TITLE
fix typo in zh-cn.json

### DIFF
--- a/src/renderer/src/i18n/locales/zh-cn.json
+++ b/src/renderer/src/i18n/locales/zh-cn.json
@@ -348,7 +348,7 @@
         "new_topic": "新建话题",
         "zoom_in": "放大界面",
         "zoom_out": "缩小界面",
-        "zoom_reset": "置缩放"
+        "zoom_reset": "重置缩放"
       }
     },
     "translate": {


### PR DESCRIPTION
修改“置缩放”为“重置缩放”
<img width="1024" alt="image" src="https://github.com/user-attachments/assets/3ad23807-3a8e-46d5-acee-81817152600f">
